### PR TITLE
fix(codegen): prevent duplicate suffix in generated service names (#30)

### DIFF
--- a/.changeset/fix-naming-suffix.md
+++ b/.changeset/fix-naming-suffix.md
@@ -1,0 +1,7 @@
+---
+"@dr_nikson/effect-grpc": patch
+---
+
+Fix duplicate suffix in generated service names (#30)
+
+Services with names already ending in "Service" (e.g., `HelloWorldService`) no longer produce duplicated names like `HelloWorldServiceService`. The code generator now correctly strips the suffix before applying naming conventions.

--- a/agents/CHANGESETS.md
+++ b/agents/CHANGESETS.md
@@ -1,0 +1,109 @@
+# Changesets: Non-Interactive Usage for AI Agents
+
+This document explains how to create changesets programmatically without using the interactive CLI.
+
+## Why Non-Interactive?
+
+The `changeset add` command requires interactive prompts and does not support non-interactive mode. To create changesets programmatically, you must manually write the changeset files.
+
+## Changeset File Format
+
+Changesets are markdown files stored in `.changeset/` with YAML frontmatter:
+
+```markdown
+---
+"@dr_nikson/effect-grpc": patch
+---
+
+Fix duplicate suffix in generated service names
+```
+
+**Structure:**
+- **Frontmatter**: Package name(s) mapped to bump type (`major`, `minor`, `patch`)
+- **Body**: Changelog description in markdown
+
+**Multiple packages:**
+```markdown
+---
+"@dr_nikson/effect-grpc": minor
+"@dr_nikson/some-other-package": patch
+---
+
+Add feature X with related utility updates
+```
+
+## File Naming
+
+Use lowercase words separated by hyphens: `{adjective}-{noun}-{verb}.md`
+
+Examples: `sharp-pots-ring.md`, `spicy-rivers-chew.md`, `calm-doors-swim.md`
+
+Any unique name works. Keep it short and lowercase.
+
+## Creating a Changeset
+
+1. **Determine the package name** - Check `packages/*/package.json` for the `name` field
+2. **Determine bump type**:
+   - `major` - Breaking changes (API changes, removed features)
+   - `minor` - New features (backwards compatible)
+   - `patch` - Bug fixes, docs, refactoring
+3. **Write a clear description** - Explain what changed and why
+4. **Create the file** in `.changeset/` directory
+
+**Example:**
+```
+File: .changeset/fix-naming-bug.md
+
+---
+"@dr_nikson/effect-grpc": patch
+---
+
+Fix duplicate suffix in generated service names when proto service already ends with "Service"
+```
+
+## Project-Specific Rules
+
+**Packages that need changesets:**
+- `@dr_nikson/effect-grpc` - The main library
+
+**Packages excluded from versioning** (no changesets needed):
+- `@dr_nikson/effect-grpc-example`
+- `@dr_nikson/effect-grpc-e2e-tests`
+
+## Writing Good Descriptions
+
+**Do:**
+- Explain what the change does
+- Mention breaking changes explicitly
+- Reference issue numbers when applicable
+
+**Don't:**
+- Write vague descriptions like "fix bug" or "update code"
+- Include implementation details irrelevant to users
+
+**Good:**
+```markdown
+Fix duplicate suffix in generated service names (#30)
+
+Services ending with "Service" no longer produce names like "HelloWorldServiceService".
+```
+
+**Bad:**
+```markdown
+Fix bug
+```
+
+## When to Create Changesets
+
+**Important:** Create the changeset as part of the final commit for a feature or fix. The changeset file should be committed together with the code changes.
+
+Create a changeset when:
+- Fixing a bug in `@dr_nikson/effect-grpc`
+- Adding a new feature
+- Making breaking changes
+- Changing public API behavior
+
+Skip changesets for:
+- Changes only to example or e2e-tests packages
+- Internal refactoring with no user-facing impact
+- Documentation-only changes in non-published files

--- a/packages/e2e-tests/proto/com/example/v1/naming_test_service.proto
+++ b/packages/e2e-tests/proto/com/example/v1/naming_test_service.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package com.example.v1;
+
+/**
+ * Test service that already ends with "Service" suffix.
+ * This tests that the code generator doesn't produce
+ * "NamingTestServiceService" when generating code.
+ * See: https://github.com/Dr-Nikson/effect-grpc/issues/30
+ */
+service NamingTestService {
+  rpc Echo(EchoRequest) returns (EchoResponse);
+}
+
+message EchoRequest {
+  string message = 1;
+}
+
+message EchoResponse {
+  string message = 1;
+}

--- a/packages/e2e-tests/src/index.test.ts
+++ b/packages/e2e-tests/src/index.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "@effect/vitest";
 
 import * as effectProto from "./generated/com/example/v1/hello_world_api_effect.js";
 import type * as proto from "./generated/com/example/v1/hello_world_api_pb.js";
+import * as namingTestProto from "./generated/com/example/v1/naming_test_service_effect.js";
 
 // Branded Port type
 type Port = number & Brand.Brand<"Port">;
@@ -159,4 +160,25 @@ describe("E2E gRPC Client-Server Tests", () => {
       ),
     ),
   );
+});
+
+/**
+ * Tests for service naming to ensure generated code doesn't have duplicate suffixes.
+ * See: https://github.com/Dr-Nikson/effect-grpc/issues/30
+ */
+describe("Service Naming - No Duplicate Suffixes (Issue #30)", () => {
+  /**
+   * This test verifies that when a proto service is named "NamingTestService"
+   * (already ending with "Service"), the generated code does NOT produce
+   * "NamingTestServiceService" or similar duplicated names.
+   */
+  it("should generate correct export names for services ending with 'Service'", () => {
+    // These would fail to import if naming were broken
+    expect(namingTestProto.NamingTestServiceTag).toBeDefined();
+    expect(namingTestProto.NamingTestServiceClientTag).toBeDefined();
+    expect(namingTestProto.namingTestServiceLiveLayer).toBeDefined();
+    expect(namingTestProto.namingTestServiceClientLiveLayer).toBeDefined();
+    expect(namingTestProto.NamingTestServiceConfigTag).toBeDefined();
+    expect(namingTestProto.NamingTestServiceProtoId).toBe("com.example.v1.NamingTestService");
+  });
 });

--- a/packages/effect-grpc/src/protocGenPlugin.ts
+++ b/packages/effect-grpc/src/protocGenPlugin.ts
@@ -89,6 +89,15 @@ interface EffectImports {
     Scope: string;
 }
 
+/**
+ * Appends a suffix to a name only if the name doesn't already end with that suffix.
+ * This prevents names like "HelloWorldServiceService" when the proto service
+ * is already named "HelloWorldService".
+ */
+function appendSuffixIfNeeded(name: string, suffix: string): string {
+    return name.endsWith(suffix) ? name : name + suffix;
+}
+
 function generateEffectService(
     f: GeneratedFile,
     service: DescService,
@@ -102,14 +111,18 @@ function generateEffectService(
 
     const importService = f.importSchema(service);
 
+    // Use appendSuffixIfNeeded to avoid duplicate suffixes (e.g., "HelloWorldServiceService")
+    const serviceName = appendSuffixIfNeeded(service.name, "Service");
+    const serviceNameLower = serviceName.charAt(0).toLowerCase() + serviceName.slice(1);
+
     const serviceId = service.typeName;
     const serviceIdSymbol = safeIdentifier(service.name + "ProtoId");
-    const serviceSymbol = safeIdentifier(service.name + "Service")
-    const grpcServiceSymbol = safeIdentifier(service.name + "GrpcService");
-    const serviceTagSymbol = safeIdentifier(service.name + "ServiceTag");
-    const serviceLiveLayerSymbol = safeIdentifier(service.name.charAt(0).toLowerCase() + service.name.slice(1) + "ServiceLiveLayer");
-    const makeTagSymbol = safeIdentifier("make" + service.name + "ServiceTag");
-    const makeLiveLayerSymbol = safeIdentifier("make" + service.name + "ServiceLiveLayer");
+    const serviceSymbol = safeIdentifier(serviceName);
+    const grpcServiceSymbol = safeIdentifier(serviceName.replace(/Service$/, "") + "GrpcService");
+    const serviceTagSymbol = safeIdentifier(serviceName + "Tag");
+    const serviceLiveLayerSymbol = safeIdentifier(serviceNameLower + "LiveLayer");
+    const makeTagSymbol = safeIdentifier("make" + serviceName + "Tag");
+    const makeLiveLayerSymbol = safeIdentifier("make" + serviceName + "LiveLayer");
 
     // Generate service ID constant with JSDoc
     f.print("/**");
@@ -313,13 +326,17 @@ function generateEffectService(
 
     f.print();
 
-    const clientSymbol = safeIdentifier(service.name + "Client");
+    // Use appendSuffixIfNeeded to avoid duplicate suffixes (e.g., "HelloWorldClientClient")
+    const clientName = appendSuffixIfNeeded(service.name, "Client");
+    const clientNameLower = clientName.charAt(0).toLowerCase() + clientName.slice(1);
+
+    const clientSymbol = safeIdentifier(clientName);
     const importEffectGrpcClient = f.import("EffectGrpcClient", packageJson.name);
-    const clientTagSymbol = safeIdentifier(service.name + "ClientTag");
-    const clientLiveLayerSymbol = safeIdentifier(service.name.charAt(0).toLowerCase() + service.name.slice(1) + "ClientLiveLayer");
+    const clientTagSymbol = safeIdentifier(clientName + "Tag");
+    const clientLiveLayerSymbol = safeIdentifier(clientNameLower + "LiveLayer");
     const configTagSymbol = safeIdentifier(service.name + "ConfigTag");
-    const makeClientTagSymbol = safeIdentifier("make" + service.name + "ClientTag");
-    const makeClientLiveLayerSymbol = safeIdentifier("make" + service.name + "ClientLiveLayer");
+    const makeClientTagSymbol = safeIdentifier("make" + clientName + "Tag");
+    const makeClientLiveLayerSymbol = safeIdentifier("make" + clientName + "LiveLayer");
 
     // Generate comprehensive JSDoc for client interface
     f.print("/**");


### PR DESCRIPTION
When a proto service name already ends with "Service" (e.g., "HelloWorldService"), the code generator was producing duplicated names like "HelloWorldServiceService".

This fix strips the "Service" suffix before applying naming conventions, ensuring correct generated names:
- HelloWorldService → HelloWorldServiceTag (not HelloWorldServiceServiceTag)
- HelloWorldService → helloWorldServiceLiveLayer (not helloWorldServiceServiceLiveLayer)

Added regression test with NamingTestService proto to verify the fix.

Closes #30 